### PR TITLE
prepare for alpheios 3.3.x

### DIFF
--- a/Latin_301/De_amicitia_embed_new.html
+++ b/Latin_301/De_amicitia_embed_new.html
@@ -10,7 +10,7 @@ layout: default
     <head>
        <meta charset="UTF-8">
           <title>Alpheios Embedded Library Treebank Translation Demo</title>
-          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/alpheios-components@latest/dist/style/style-components.min.css"/>
+          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/alpheios-components@beta/dist/style/style-components.min.css"/>
           <meta name="alpheios-v2-treebank-diagram-url"
              data-alpheios_tb_src="https://alpheios.net/alpheios-treebanks/DOC.html?chunk=SENTENCE&w=WORD"/>
     </head>
@@ -1065,9 +1065,10 @@ layout: default
          </div>
       </div><script type="text/javascript">
                 document.addEventListener("DOMContentLoaded", function(event) {
-                import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {
+                import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@beta/dist/alpheios-embedded.min.js").then(embedLib => {
                 window.AlpheiosEmbed.importDependencies({
-                mode: 'cdn' 
+                mode: 'custom' ,
+                libs: { components: "https://cdn.jsdelivr.net/npm/alpheios-components@beta/dist/alpheios-components.min.js"}
                 }).then(Embedded => {
                 new Embedded({clientId: 'alpheios-sample-cdn'}).activate();
                 }).catch(e => {

--- a/Latin_301/test_1.html
+++ b/Latin_301/test_1.html
@@ -15,7 +15,10 @@ layout: default
            
    </head>
   
-   <body>
+   <body
+     data-alpheios_tb_app="perseids-treebank-template"
+     data-alpheios_tb_app_version="2.2.0" 
+     data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
       <p>This is a Test of Alpheios for classroom use</p>
       <div class="alpheios-enabled" style="max-width:500px;">
          <h1 data-alpheios-ignore="all">Latin 301/3: De Amicitia</h1>

--- a/classroom_demos/demo_1.html
+++ b/classroom_demos/demo_1.html
@@ -15,7 +15,10 @@ layout: default
                         <meta name="alpheios-v2-treebank-diagram-url" data-alpheios_tb_src="https://alpheios.net/alpheios-treebanks/DOC.html?chunk=SENTENCE&amp;w=WORD"></meta>
         </head>
         
-        <body>
+        <body
+          data-alpheios_tb_app="perseids-treebank-template"
+          data-alpheios_tb_app_version="2.2.0" 
+          data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
             
             <div class="alpheios-enabled" style="max-width:500px;">
                 <h1 data-alpheios-ignore="all">Alpheios Tools</h1>

--- a/tests/testudo-1.html
+++ b/tests/testudo-1.html
@@ -14,7 +14,10 @@ layout: default
       data-alpheios_tb_src="https://perseids-publications.github.io/treebank-template/embed/DOC/SENTENCE?w=WORD"
 </head>
 
-<body>
+<body
+   data-alpheios_tb_app="perseids-treebank-template"
+   data-alpheios_tb_app_version="2.2.0" 
+   data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
       	import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/testudo-2.html
+++ b/tests/testudo-2.html
@@ -14,7 +14,10 @@ layout: default
       data-alpheios_tb_src="https://github.com/rgorman/VG-treebank-display/embed/DOC/SENTENCE?w=WORD"
 </head>
 
-<body>
+<body
+  data-alpheios_tb_app="perseids-treebank-template"
+  data-alpheios_tb_app_version="2.2.0" 
+  data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
       	import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/testudo-3.html
+++ b/tests/testudo-3.html
@@ -14,7 +14,10 @@ layout: default
       data-alpheios_tb_src="https://github.com/rgorman/VG-treebank-display/public/sml/DOC/SENTENCE?w=WORD"
 </head>
 
-<body>
+<body
+  data-alpheios_tb_app="perseids-treebank-template"
+  data-alpheios_tb_app_version="2.2.0" 
+  data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
       	import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/testudo-4.html
+++ b/tests/testudo-4.html
@@ -14,7 +14,10 @@ layout: default
       data-alpheios_tb_src="https://github.com/rgorman/VG-treebank-display/public/sml/DOC/SENTENCE?w=WORD"
 </head>
 
-<body>
+<body
+   data-alpheios_tb_app="perseids-treebank-template"
+   data-alpheios_tb_app_version="2.2.0" 
+   data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
       	import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/tree_embed_1.html
+++ b/tests/tree_embed_1.html
@@ -9,7 +9,10 @@
       data-alpheios_tb_src="http://alpheios.net/alpheios-treebanks/DOC.html?chunk=SENTENCE&w=WORD"/>
 </head>
 
-<body>
+<body
+   data-alpheios_tb_app="perseids-treebank-template"
+   data-alpheios_tb_app_version="2.2.0" 
+   data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
           import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/tree_embed_2.html
+++ b/tests/tree_embed_2.html
@@ -9,7 +9,10 @@
       data-alpheios_tb_src="http://alpheios.net/alpheios-treebanks/DOC.html?chunk=SENTENCE&w=WORD"/>
 </head>
 
-<body>
+<body
+   data-alpheios_tb_app="perseids-treebank-template"
+   data-alpheios_tb_app_version="2.2.0" 
+   data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
           import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {

--- a/tests/tree_embed_3.html
+++ b/tests/tree_embed_3.html
@@ -9,7 +9,10 @@
       data-alpheios_tb_src="https://alpheios.net/alpheios-treebanks/DOC.html?chunk=SENTENCE&w=WORD"/>
 </head>
 
-<body>
+<body
+  data-alpheios_tb_app="perseids-treebank-template"
+  data-alpheios_tb_app_version="2.2.0" 
+  data-alpheios_tb_app_url="https://trees.alpheios.net/embed/DOC/SENTENCE">
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", function(event) {
           import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {


### PR DESCRIPTION
Bob,

These changes will ensure that your pages keep working as before when the new Alpheios release goes live (probably not until the end of June).

The currently released code doesn't know anything about the new attributes, so this change doesn't disrupt functionality now.

I also created a copy of the Latin_301/De_amiticia_embed.html page as Latin_301/De_amiticia_embed_new.html which points at the Beta version of the Alpheios code so that you can see how the page will work once the new Alpheios release is published.  For the most part it should be the same. There are visual differences:

- the tree is a little zoomier as we try to perfect the width
- the popup should have little red errors and the tree diagram to show that they have been disambiguated

Once we work through getting your own tree repositories setup , then the only thing that you would have to change to use them is to update the data-alpheios_tb_app_url setting to point at the correct repository. You might also change the data-alpheios_tb_ref values if you use different file names or switch to the new data-alpheios_tb_doc, and data-alpheios_tb_sent attributes.

Let me know if you have any questions about this and thanks again for your patience as we work through the kinks.